### PR TITLE
bundler support - use bundle exec when options.bundler is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ The options are the same as what's supported by `slimrb`.
 - `rails: true`
 - `translator: true`
 - `logicLess: true`
+
+Set `bundler: true` to invoke `slimrb` via bundler.

--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -9,44 +9,49 @@ module.exports = (options = {}) ->
 	# build a command with arguments
 	cmnd = 'slimrb'
 	args = []
+
+	if options.bundler
+		cmnd = 'bundle'
+		args = ['exec', 'slimrb']
+
 	args.push '-s' # read input from standard input
 	args.push '-p' if options.pretty
 	args.push '-e' if options.erb
 	args.push '-c' if options.compile
 	args.push '-r' if options.rails
-	args.push '-t' if options.translator 
+	args.push '-t' if options.translator
 	args.push '-l' if options.logicLess
 
 	through.obj (file, encoding, callback) ->
-		
+
 		if file.isNull()
 			@push file
 			return callback()
-		
+
 		if file.isStream()
 			@emit 'error', new gutil.PluginError PLUGIN_NAME, 'Streaming not supported'
 			return callback()
-		
+
 		# relace the extension
 		ext = if options.erb then '.erb' else '.html'
 		file.path = gutil.replaceExtension file.path, ext
-		
+
 		program = spawn cmnd, args
-		
+
 		# create buffer
 		b = new Buffer 0
-		
+
 		# add data to buffer
 		program.stdout.on 'readable', =>
 			while chunk = program.stdout.read()
 				b = Buffer.concat [b, chunk], b.length + chunk.length
-		
+
 		# return data
 		program.stdout.on 'end', =>
 			file.contents = b
 			@push file
 			callback()
-		
+
 		# pass data to standard input
 		program.stdin.write file.contents, =>
 			program.stdin.end()

--- a/index.js
+++ b/index.js
@@ -16,6 +16,10 @@
     }
     cmnd = 'slimrb';
     args = [];
+    if (options.bundler) {
+      cmnd = 'bundle';
+      args = ['exec', 'slimrb'];
+    }
     args.push('-s');
     if (options.pretty) {
       args.push('-p');

--- a/test/main.coffee
+++ b/test/main.coffee
@@ -1,7 +1,7 @@
 should = require 'should'
 slim = require '../'
 gutil = require 'gulp-util'
-fs = require 'fs' 
+fs = require 'fs'
 path = require 'path'
 
 createFile = (slimFileName, contents) ->
@@ -24,7 +24,7 @@ describe 'gulp-slim', () ->
         data.should.equal emptyFile
         done()
       stream.write emptyFile
-    
+
     it 'should emit error when file isStream()', (done) ->
       stream = slim()
       streamFile =
@@ -34,10 +34,10 @@ describe 'gulp-slim', () ->
         err.message.should.equal 'Streaming not supported'
         done()
       stream.write streamFile
-    
+
     it 'should compile single slim file', (done) ->
       slimFile = createFile 'test.slim'
-    
+
       stream = slim()
       stream.on 'data', (htmlFile) ->
         should.exist htmlFile
@@ -48,10 +48,10 @@ describe 'gulp-slim', () ->
         String(htmlFile.contents).should.equal fs.readFileSync path.join(__dirname, 'expect/test.html'), 'utf8'
         done()
       stream.write slimFile
-    
+
     it 'should compile single slim file with pretty option', (done) ->
       slimFile = createFile 'test.slim'
-    
+
       stream = slim pretty:true
       stream.on 'data', (htmlFile) ->
         should.exist htmlFile
@@ -62,3 +62,5 @@ describe 'gulp-slim', () ->
         String(htmlFile.contents).should.equal fs.readFileSync path.join(__dirname, 'expect/test-pretty.html'), 'utf8'
         done()
       stream.write slimFile
+
+    it 'should invoke slimrb via bundler with bundler option'


### PR DESCRIPTION
I am having trouble on my ci environment as the ci system doesn't allow globally installed gems. Please consider accepting this feature. Thanks!
