### PR TITLE
bugfix: win-spawn should be a non-dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
   "dependencies": {
     "coffee-script": "*",
     "through2": "*",
-    "gulp-util": "*"
+    "gulp-util": "*",
+    "win-spawn": "^2.0.0"
   },
   "devDependencies": {
     "should": "*",
     "mocha": "*",
     "gulp": "*",
-    "gulp-coffee": "*",
-    "win-spawn": "^2.0.0"
+    "gulp-coffee": "*"
   },
   "scripts": {
     "test": "node_modules/.bin/mocha --compilers coffee:coffee-script --require coffee-script/register -R spec"


### PR DESCRIPTION
Quick fix for win-spawn being incorrectly listed as a dev dependency, whereas it's actually only required by the main executable.
