### PR TITLE
swap win-spawn for spawn-cmd (windows support)

### DIFF
--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -1,4 +1,4 @@
-spawn = require 'win-spawn'
+spawn = require('spawn-cmd').spawn
 through  = require 'through2'
 gutil = require 'gulp-util'
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 (function() {
   var PLUGIN_NAME, gutil, spawn, through;
 
-  spawn = require('win-spawn');
+  spawn = require('spawn-cmd').spawn;
 
   through = require('through2');
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   ],
   "dependencies": {
     "coffee-script": "*",
-    "through2": "*",
     "gulp-util": "*",
-    "win-spawn": "^2.0.0"
+    "spawn-cmd": "0.0.2",
+    "through2": "*"
   },
   "devDependencies": {
     "should": "*",


### PR DESCRIPTION
Seems to be something wrong with win-spawn's when running multiple instances
Using this really tiny thing instead -- https://github.com/featurist/spawn-cmd/blob/master/spawn.js
