### PR TITLE
Update through2 dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "coffee-script": "^1.9.1",
     "gulp-util": "^3.0.4",
     "spawn-cmd": "0.0.2",
-    "through2": "^0.6.3"
+    "through2": "^0.6.5"
   },
   "devDependencies": {
     "gulp": "^3.8.11",


### PR DESCRIPTION
Hey there! I was experiencing a strange bug with this lovely package: using its latest version, as well as the latest Gulp and Slim, _one_ file in a tree of many was _consistently_ being transformed into an empty HTML file. I had a folder tree that looked something like this:

```
src
├── index.slim
├── project
│   ├── checkout
│   │   ├── confirmation.slim
│   │   ├── footer.slim
│   │   ├── header.slim
│   │   └── main.slim
│   ├── common
│   │   └── layout.slim
│   ├── home
│   │   ├── footer.slim
│   │   ├── header.slim
│   │   └── main.slim
│   ├── shop
│   │   ├── detail.slim
│   │   ├── footer.slim
│   │   ├── header.slim
│   │   └── main.slim
│   └── static
│       ├── about.slim
│       ├── faq.slim
│       ├── footer.slim
│       ├── header.slim
│       ├── partners.slim
│       └── press.slim
└──
```

...and every file was being compiled successfully but `index.slim` unless I ran `gulp html` on its own; running the complete task suite generated an empty `index.html` file every time. I finally managed to squash the bug by upgrading `through2`, and now it works beautifully.

Thanks for all your hard work on this plugin! You saved me from certain Jade.